### PR TITLE
Added Carthage compatible badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Masonry [![Build Status](https://travis-ci.org/SnapKit/Masonry.svg?branch=master)](https://travis-ci.org/SnapKit/Masonry) [![Coverage Status](https://img.shields.io/coveralls/SnapKit/Masonry.svg?style=flat-square)](https://coveralls.io/r/SnapKit/Masonry)
+#Masonry [![Build Status](https://travis-ci.org/SnapKit/Masonry.svg?branch=master)](https://travis-ci.org/SnapKit/Masonry) [![Coverage Status](https://img.shields.io/coveralls/SnapKit/Masonry.svg?style=flat-square)](https://coveralls.io/r/SnapKit/Masonry) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 **Masonry is being deprecated into a bugfix only state as more developers will be moving to Swift. Going forward we recommend using [SnapKit](https://github.com/SnapKit/SnapKit) as it supports Swift and provides better type safety with a simpler API**.
 
@@ -265,7 +265,7 @@ Alternatively if you are only updating the constant value of the constraint you 
         make.width.lessThanOrEqualTo(self);
         make.height.lessThanOrEqualTo(self);
     }];
-    
+
     //according to apple super should be called at end of method
     [super updateConstraints];
 }
@@ -280,7 +280,7 @@ Alternatively if you are only updating the constant value of the constraint you 
 - (void)changeButtonPosition {
     [self.button mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.size.equalTo(self.buttonSize);
-        
+
         if (topLeft) {
         	make.top.and.left.offset(10);
         } else {
@@ -346,9 +346,9 @@ Get busy Masoning
 Copy the included code snippets to ``~/Library/Developer/Xcode/UserData/CodeSnippets`` to write your masonry blocks at lightning speed!
 
 `mas_make` -> `[<view> mas_makeConstraints:^(MASConstraintMaker *make){<code>}];`
-    
+
 `mas_update` -> `[<view> mas_updateConstraints:^(MASConstraintMaker *make){<code>}];`
-    
+
 `mas_remake` -> `[<view> mas_remakeConstraints:^(MASConstraintMaker *make){<code>}];`
 
 ## Features


### PR DESCRIPTION
Should we add a new tag now when the project works with Carthage so we can point at that instead of `master`?