### PR TITLE
Added support UIViewController's topLayoutGuide and bottomLayoutGuide

### DIFF
--- a/Masonry.xcodeproj/project.pbxproj
+++ b/Masonry.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		3AED06201AD5A1400053CC65 /* MASCompositeConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05DC1AD5A0470053CC65 /* MASCompositeConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3AED06211AD5A1400053CC65 /* NSLayoutConstraint+MASDebugAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05ED1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3AED06221AD5A1400053CC65 /* MASConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05DE1AD5A0470053CC65 /* MASConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		446A261F1B3A78F500115471 /* ViewController+MASAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 446A261D1B3A78F500115471 /* ViewController+MASAdditions.h */; };
+		446A26201B3A78F500115471 /* ViewController+MASAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 446A261E1B3A78F500115471 /* ViewController+MASAdditions.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -82,6 +84,8 @@
 		3AED05F01AD5A0470053CC65 /* View+MASAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "View+MASAdditions.m"; sourceTree = "<group>"; };
 		3AED05F11AD5A0470053CC65 /* View+MASShorthandAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "View+MASShorthandAdditions.h"; sourceTree = "<group>"; };
 		3AED06271AD5A1400053CC65 /* Masonry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Masonry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		446A261D1B3A78F500115471 /* ViewController+MASAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ViewController+MASAdditions.h"; sourceTree = "<group>"; };
+		446A261E1B3A78F500115471 /* ViewController+MASAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ViewController+MASAdditions.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -146,6 +150,8 @@
 				3AED05ED1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.h */,
 				3AED05EE1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.m */,
 				3AED05BA1AD59FD40053CC65 /* Supporting Files */,
+				446A261D1B3A78F500115471 /* ViewController+MASAdditions.h */,
+				446A261E1B3A78F500115471 /* ViewController+MASAdditions.m */,
 			);
 			path = Masonry;
 			sourceTree = "<group>";
@@ -165,6 +171,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				446A261F1B3A78F500115471 /* ViewController+MASAdditions.h in Headers */,
 				3AED06051AD5A0470053CC65 /* View+MASAdditions.h in Headers */,
 				3AED06071AD5A0470053CC65 /* View+MASShorthandAdditions.h in Headers */,
 				3AED05FC1AD5A0470053CC65 /* MASViewAttribute.h in Headers */,
@@ -296,6 +303,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				446A26201B3A78F500115471 /* ViewController+MASAdditions.m in Sources */,
 				3AED06011AD5A0470053CC65 /* NSArray+MASAdditions.m in Sources */,
 				3AED05FD1AD5A0470053CC65 /* MASViewAttribute.m in Sources */,
 				3AED05FA1AD5A0470053CC65 /* MASLayoutConstraint.m in Sources */,

--- a/Masonry/MASViewConstraint.m
+++ b/Masonry/MASViewConstraint.m
@@ -339,12 +339,14 @@ static char kInstalledConstraintsKey;
     layoutConstraint.priority = self.layoutPriority;
     layoutConstraint.mas_key = self.mas_key;
     
-    if (secondLayoutItem) {
+    if ([secondLayoutItem isKindOfClass:[MAS_VIEW class]]) {
         MAS_VIEW *closestCommonSuperview = [firstLayoutItem mas_closestCommonSuperview:secondLayoutItem];
         NSAssert(closestCommonSuperview,
                  @"couldn't find a common superview for %@ and %@",
                  firstLayoutItem, secondLayoutItem);
         self.installedView = closestCommonSuperview;
+    } else if (firstLayoutItem.superview) {
+        self.installedView = firstLayoutItem.superview;
     } else {
         self.installedView = firstLayoutItem;
     }

--- a/Masonry/Masonry.h
+++ b/Masonry/Masonry.h
@@ -26,3 +26,4 @@ FOUNDATION_EXPORT const unsigned char MasonryVersionString[];
 #import "MASConstraintMaker.h"
 #import "MASLayoutConstraint.h"
 #import "NSLayoutConstraint+MASDebugAdditions.h"
+#import "ViewController+MASAdditions.h"

--- a/Masonry/ViewController+MASAdditions.h
+++ b/Masonry/ViewController+MASAdditions.h
@@ -1,0 +1,20 @@
+//
+//  ViewController_MASAdditions.h
+//  Masonry
+//
+//  Created by Ray Lillywhite on 6/23/15.
+//  Copyright © 2015 Jonas Budelmann. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+@class MASViewAttribute;
+@interface UIViewController (MASAdditions)
+
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_topLayoutGuide;
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_bottomLayoutGuide;
+
+@end
+#endif

--- a/Masonry/ViewController+MASAdditions.m
+++ b/Masonry/ViewController+MASAdditions.m
@@ -1,0 +1,24 @@
+//
+//  NSObject+ViewController_MASAdditions.m
+//  Masonry
+//
+//  Created by Ray Lillywhite on 6/23/15.
+//  Copyright © 2015 Jonas Budelmann. All rights reserved.
+//
+
+#import "ViewController+MASAdditions.h"
+#import "MASViewConstraint.h"
+
+#if TARGET_OS_IPHONE
+@implementation UIViewController (MASAdditions)
+
+- (MASViewAttribute *)mas_topLayoutGuide {
+    return [[MASViewAttribute alloc] initWithView:self.topLayoutGuide layoutAttribute:NSLayoutAttributeBottom];
+}
+
+- (MASViewAttribute *)mas_bottomLayoutGuide {
+    return [[MASViewAttribute alloc] initWithView:self.bottomLayoutGuide layoutAttribute:NSLayoutAttributeTop];
+}
+
+@end
+#endif

--- a/Tests/Specs/MASViewConstraintSpec.m
+++ b/Tests/Specs/MASViewConstraintSpec.m
@@ -501,7 +501,7 @@ SpecBegin(MASViewConstraint) {
     expect(constraint.layoutConstraint.secondItem).to.beNil();
     expect(constraint.layoutConstraint.relation).to.equal(NSLayoutRelationEqual);
     expect(constraint.layoutConstraint.constant).to.equal(10);
-    expect(constraint.firstViewAttribute.view.constraints[0]).to.beIdenticalTo(constraint.layoutConstraint);
+    expect(constraint.firstViewAttribute.view.superview.constraints[0]).to.beIdenticalTo(constraint.layoutConstraint);
 }
 
 


### PR DESCRIPTION
This improves the API for using `UIViewController`'s `topLayoutGuide` and `bottomLayoutGuide` with Masonry by adding `mas_topLayoutGuide` and `mas_bottomLayoutGuide` to `UIViewController`, and fixes issues in iOS 9 (#207) from assuming that the topLayoutGuide and bottomLayoutGuide are UIViews (as described in #27).

A couple things to note:

- `MASViewAttribute`'s view property will contain a UILayoutSupport that, at least in iOS 9, is not really a view. Should `MASViewAttribute` be renamed to something like `MASLayoutAttribute` and its `view` property changed to an `id` with a name like `receiver`?

- I changed the logic for determining which view to install the constraint on to more closely match SnapKit's logic because in iOS 9 the common superview calculation won't work since the layout guides are not views. But that changes which view width/height constraints get installed to (the new behavior seems to match SnapKit, and doesn't seem to cause any problems in my project, but I'm not sure if it could cause problems in other projects). I think this could be prevented by inverting part of SnapKit's logic and instead of installing it on the first view's superview if it exists, first check if it's a width/height constraint, and if so, install on the first view directly.