### PR TITLE
Added edgesWithoutTop, edgesWithoutLeft, edgesWithoutRight, edgesWithoutBottom constraints

### DIFF
--- a/Masonry/MASConstraintMaker.h
+++ b/Masonry/MASConstraintMaker.h
@@ -88,6 +88,34 @@ typedef NS_OPTIONS(NSInteger, MASAttribute) {
 @property (nonatomic, strong, readonly) MASConstraint *edges;
 
 /**
+ *	Creates a MASCompositeConstraint with type MASCompositeConstraintTypeEdges
+ *  which generates the appropriate MASViewConstraint children (left, bottom, right)
+ *  with the first item set to the makers associated view
+ */
+@property (nonatomic, strong, readonly) MASConstraint *edgesWithoutTop;
+
+/**
+ *	Creates a MASCompositeConstraint with type MASCompositeConstraintTypeEdges
+ *  which generates the appropriate MASViewConstraint children (top, bottom, right)
+ *  with the first item set to the makers associated view
+ */
+@property (nonatomic, strong, readonly) MASConstraint *edgesWithoutLeft;
+
+/**
+ *	Creates a MASCompositeConstraint with type MASCompositeConstraintTypeEdges
+ *  which generates the appropriate MASViewConstraint children (top, left, bottom)
+ *  with the first item set to the makers associated view
+ */
+@property (nonatomic, strong, readonly) MASConstraint *edgesWithoutRight;
+
+/**
+ *	Creates a MASCompositeConstraint with type MASCompositeConstraintTypeEdges
+ *  which generates the appropriate MASViewConstraint children (top, left, right)
+ *  with the first item set to the makers associated view
+ */
+@property (nonatomic, strong, readonly) MASConstraint *edgesWithoutBottom;
+
+/**
  *	Creates a MASCompositeConstraint with type MASCompositeConstraintTypeSize
  *  which generates the appropriate MASViewConstraint children (width, height)
  *  with the first item set to the makers associated view

--- a/Masonry/MASConstraintMaker.m
+++ b/Masonry/MASConstraintMaker.m
@@ -225,6 +225,22 @@
     return [self addConstraintWithAttributes:MASAttributeTop | MASAttributeLeft | MASAttributeRight | MASAttributeBottom];
 }
 
+- (MASConstraint *)edgesWithoutTop {
+    return [self addConstraintWithAttributes:MASAttributeLeft | MASAttributeRight | MASAttributeBottom];
+}
+
+- (MASConstraint *)edgesWithoutLeft {
+    return [self addConstraintWithAttributes:MASAttributeTop | MASAttributeRight | MASAttributeBottom];
+}
+
+- (MASConstraint *)edgesWithoutRight {
+    return [self addConstraintWithAttributes:MASAttributeTop | MASAttributeLeft | MASAttributeBottom];
+}
+
+- (MASConstraint *)edgesWithoutBottom {
+    return [self addConstraintWithAttributes:MASAttributeTop | MASAttributeLeft | MASAttributeRight];
+}
+
 - (MASConstraint *)size {
     return [self addConstraintWithAttributes:MASAttributeWidth | MASAttributeHeight];
 }


### PR DESCRIPTION
I had a lot of use cases when I need to setup 3 of 4 edges to superview.

Made to replace this:
```
[topView mas_makeConstraints:^(MASConstraintMaker *make) {
    make.top.and.leading.mas_equalTo(20);
    make.trailing.mas_equal(-20);
}];
[bottomView mas_makeConstraints:^(MASConstraintMaker *make) {
    make.leading.mas_equalTo(20);
    make.bottom.and.trailing.mas_equalTo(-20);
    make.top.equalTo(topView.mas_bottom).with.offset(20);
}];
```
with this:
```
[topView mas_makeConstraints:^(MASConstraintMaker *make) {
    make.edgesWithoutBottom.mas_equalTo(UIEdgeInsetsMake(20,20,20,20));
}];
[bottomView mas_makeConstraints:^(MASConstraintMaker *make) {
    make.edgesWithoutTop.mas_equalTo(UIEdgeInsetsMake(20,20,20,20));
    make.top.equalTo(topView.mas_bottom).with.offset(20);
}];
```