### PR TITLE
fix a little issue about  MASAttachKeys(...)

### DIFF
--- a/Masonry/MASUtilities.h
+++ b/Masonry/MASUtilities.h
@@ -49,13 +49,15 @@
  *
  *  MASAttachKeys(view1, view2);
  */
-#define MASAttachKeys(...)                                                    \
-    NSDictionary *keyPairs = NSDictionaryOfVariableBindings(__VA_ARGS__);     \
-    for (id key in keyPairs.allKeys) {                                        \
-        id obj = keyPairs[key];                                               \
-        NSAssert([obj respondsToSelector:@selector(setMas_key:)],             \
-                 @"Cannot attach mas_key to %@", obj);                        \
-        [obj setMas_key:key];                                                 \
+#define MASAttachKeys(...)                                                        \
+    {                                                                             \
+        NSDictionary *keyPairs = NSDictionaryOfVariableBindings(__VA_ARGS__);     \
+        for (id key in keyPairs.allKeys) {                                        \
+            id obj = keyPairs[key];                                               \
+            NSAssert([obj respondsToSelector:@selector(setMas_key:)],             \
+                     @"Cannot attach mas_key to %@", obj);                        \
+            [obj setMas_key:key];                                                 \
+        }                                                                         \
     }
 
 /**


### PR DESCRIPTION
if we have many view in a method, so we want to use MASAttachKeys(...)  many times.
for example:

- (void)initSubviews
{
    UIView *view1 = [UIView new];
    UIView *view2 = [UIView new];
    UIView *view3 = [UIView new];
    MASAttachKeys(view1,view2,view3);

    UIView *view4 = [UIView new];
    UIView *view5 = [UIView new];
    UIView *view6 = [UIView new];
    MASAttachKeys(view4,view5,view6);
}
than there is a error: Redefinition of 'keyPairs'
I fix it by add a "{ }"