### PR TITLE
Remove 'and' semantic.

### DIFF
--- a/Masonry/MASConstraint.h
+++ b/Masonry/MASConstraint.h
@@ -108,11 +108,6 @@
 - (MASConstraint *)with;
 
 /**
- *	Optional semantic property which has no effect but improves the readability of constraint
- */
-- (MASConstraint *)and;
-
-/**
  *	Creates a new MASCompositeConstraint with the called attribute and reciever
  */
 - (MASConstraint *)left;

--- a/Masonry/MASConstraint.m
+++ b/Masonry/MASConstraint.m
@@ -154,10 +154,6 @@
     return self;
 }
 
-- (MASConstraint *)and {
-    return self;
-}
-
 #pragma mark - Chaining
 
 - (MASConstraint *)addConstraintWithLayoutAttribute:(NSLayoutAttribute __unused)layoutAttribute {

--- a/Tests/Specs/MASCompositeConstraintSpec.m
+++ b/Tests/Specs/MASCompositeConstraintSpec.m
@@ -182,7 +182,7 @@ SpecBegin(MASCompositeConstraint) {
     composite.delegate = delegate;
     expect(composite.childConstraints.count).to.equal(2);
     
-    MASConstraint *result = (id)composite.and.bottom;
+    MASConstraint *result = (id)composite.with.bottom;
     expect(result).to.beIdenticalTo(composite);
     expect(delegate.chainedConstraints).to.equal(@[composite]);
     expect(composite.childConstraints.count).to.equal(3);

--- a/Tests/Specs/MASViewConstraintSpec.m
+++ b/Tests/Specs/MASViewConstraintSpec.m
@@ -527,7 +527,7 @@ SpecBegin(MASViewConstraint) {
 }
 
 - (void)testAttributeChainingShouldCallDelegate {
-    MASViewConstraint *result = (id)constraint.and.bottom;
+    MASViewConstraint *result = (id)constraint.with.bottom;
     expect(result.firstViewAttribute.layoutAttribute).to.equal(@(NSLayoutAttributeBottom));
     expect(delegate.chainedConstraints).to.equal(@[constraint]);
 }


### PR DESCRIPTION
Hi there, I'm fully expecting this PR to be closed, but it's more of a question.

I've recently brought in Masonry into a project that needs to support iOS7 (thus couldn't use SnapKit, which I have used extensively over the last year and love to bits) and after I brought it into the project, the 'and' semantic was causing a build failure.

I know a lot of people who have used Masonry have likely relied on this API, so I'm not suggesting it's complete removal. It's more of a question of why do you think it's causing my build to fail?

I get a very helpful build error along the lines of:
"*/Pods/Headers/Public/Masonry/MASConstraint.h:113:20: Expected selector for Objective-C method"

Any help would be greatly appreciated.