### PR TITLE
Eliminate cast to CGFloat when comparing as int.

### DIFF
--- a/Masonry/NSArray+MASAdditions.m
+++ b/Masonry/NSArray+MASAdditions.m
@@ -53,7 +53,7 @@
                 if (prev) {
                     make.width.equalTo(prev);
                     make.left.equalTo(prev.mas_right).offset(fixedSpacing);
-                    if (i == (CGFloat)self.count - 1) {//last one
+                    if (i == self.count - 1) {//last one
                         make.right.equalTo(tempSuperView).offset(-tailSpacing);
                     }
                 }
@@ -73,7 +73,7 @@
                 if (prev) {
                     make.height.equalTo(prev);
                     make.top.equalTo(prev.mas_bottom).offset(fixedSpacing);
-                    if (i == (CGFloat)self.count - 1) {//last one
+                    if (i == self.count - 1) {//last one
                         make.bottom.equalTo(tempSuperView).offset(-tailSpacing);
                     }                    
                 }
@@ -102,7 +102,7 @@
                 if (prev) {
                     CGFloat offset = (1-(i/((CGFloat)self.count-1)))*(fixedItemLength+leadSpacing)-i*tailSpacing/(((CGFloat)self.count-1));
                     make.width.equalTo(@(fixedItemLength));
-                    if (i == (CGFloat)self.count - 1) {//last one
+                    if (i == self.count - 1) {//last one
                         make.right.equalTo(tempSuperView).offset(-tailSpacing);
                     }
                     else {
@@ -125,7 +125,7 @@
                 if (prev) {
                     CGFloat offset = (1-(i/((CGFloat)self.count-1)))*(fixedItemLength+leadSpacing)-i*tailSpacing/(((CGFloat)self.count-1));
                     make.height.equalTo(@(fixedItemLength));
-                    if (i == (CGFloat)self.count - 1) {//last one
+                    if (i == self.count - 1) {//last one
                         make.bottom.equalTo(tempSuperView).offset(-tailSpacing);
                     }
                     else {


### PR DESCRIPTION
Hello, I noticed a cast to a CGFloat that looked like it wasn't meant to be there because it's comparing to an int.

Thanks for the great project, I use Masonry often!