### PR TITLE
bug fix: use greaterThanOrEqualTo or lessThanOrEqualTo to add a attri…

### DIFF
--- a/Masonry/MASViewConstraint.m
+++ b/Masonry/MASViewConstraint.m
@@ -175,6 +175,7 @@ static char kInstalledConstraintsKey;
             NSMutableArray *children = NSMutableArray.new;
             for (id attr in attribute) {
                 MASViewConstraint *viewConstraint = [self copy];
+                viewConstraint.layoutRelation = relation;
                 viewConstraint.secondViewAttribute = attr;
                 [children addObject:viewConstraint];
             }

--- a/Tests/Specs/NSLayoutConstraint+MASDebugAdditionsSpec.m
+++ b/Tests/Specs/NSLayoutConstraint+MASDebugAdditionsSpec.m
@@ -53,7 +53,7 @@ SpecBegin(NSLayoutConstraint_MASDebugAdditions)
     }];
 
 
-    NSString *description = [NSString stringWithFormat:@"<MASLayoutConstraint:left[0] %@:newView1.left == %@:newView2.left>", MAS_VIEW.class, MAS_VIEW.class];
+    NSString *description = [NSString stringWithFormat:@"<MASLayoutConstraint:left[0] %@:newView1.left >= %@:newView2.left>", MAS_VIEW.class, MAS_VIEW.class];
     expect([superview.constraints[0] description]).to.equal(description);
 }
 


### PR DESCRIPTION
I guess it is a bug.
When use lessThanOrEqualTo or greaterThanOrEqualTo to add a array attribute, the viewConstraint layoutRelation is NSLayoutRelationEqual(default).
