### PR TITLE
Added mas_removeExistingConstraints method to UIView's additions.

### DIFF
--- a/Masonry/MASConstraintMaker.m
+++ b/Masonry/MASConstraintMaker.m
@@ -34,10 +34,7 @@
 
 - (NSArray *)install {
     if (self.removeExisting) {
-        NSArray *installedConstraints = [MASViewConstraint installedConstraintsForView:self.view];
-        for (MASConstraint *constraint in installedConstraints) {
-            [constraint uninstall];
-        }
+        [self.view mas_removeExistingConstraints];
     }
     NSArray *constraints = self.constraints.copy;
     for (MASConstraint *constraint in constraints) {

--- a/Masonry/NSArray+MASAdditions.h
+++ b/Masonry/NSArray+MASAdditions.h
@@ -50,6 +50,11 @@ typedef NS_ENUM(NSUInteger, MASAxisType) {
 - (NSArray *)mas_remakeConstraints:(void (NS_NOESCAPE ^)(MASConstraintMaker *make))block;
 
 /**
+ *  Removes all constraints previously installed on each view in the callee.
+ */
+- (void)mas_removeExistingConstraints;
+
+/**
  *  distribute with fixed spacing
  *
  *  @param axisType     which axis to distribute items along

--- a/Masonry/NSArray+MASAdditions.m
+++ b/Masonry/NSArray+MASAdditions.m
@@ -38,6 +38,13 @@
     return constraints;
 }
 
+- (void)mas_removeExistingConstraints {
+    for (MAS_VIEW *view in self) {
+        NSAssert([view isKindOfClass:[MAS_VIEW class]], @"All objects in the array must be views");
+        [view mas_removeExistingConstraints];
+    }
+}
+
 - (void)mas_distributeViewsAlongAxis:(MASAxisType)axisType withFixedSpacing:(CGFloat)fixedSpacing leadSpacing:(CGFloat)leadSpacing tailSpacing:(CGFloat)tailSpacing {
     if (self.count < 2) {
         NSAssert(self.count>1,@"views to distribute need to bigger than one");

--- a/Masonry/View+MASAdditions.h
+++ b/Masonry/View+MASAdditions.h
@@ -98,4 +98,9 @@
  */
 - (NSArray *)mas_remakeConstraints:(void(NS_NOESCAPE ^)(MASConstraintMaker *make))block;
 
+/**
+ *  Removes all constraints previously installed on the callee view.
+ */
+- (void)mas_removeExistingConstraints;
+
 @end

--- a/Masonry/View+MASAdditions.m
+++ b/Masonry/View+MASAdditions.m
@@ -7,6 +7,7 @@
 //
 
 #import "View+MASAdditions.h"
+#import "MASViewConstraint.h"
 #import <objc/runtime.h>
 
 @implementation MAS_VIEW (MASAdditions)
@@ -32,6 +33,13 @@
     constraintMaker.removeExisting = YES;
     block(constraintMaker);
     return [constraintMaker install];
+}
+
+- (void)mas_removeExistingConstraints {
+    NSArray *installedConstraints = [MASViewConstraint installedConstraintsForView:self];
+    for (MASConstraint *constraint in installedConstraints) {
+        [constraint uninstall];
+    }
 }
 
 #pragma mark - NSLayoutAttribute properties

--- a/Masonry/View+MASShorthandAdditions.h
+++ b/Masonry/View+MASShorthandAdditions.h
@@ -52,6 +52,7 @@
 - (NSArray *)makeConstraints:(void(^)(MASConstraintMaker *make))block;
 - (NSArray *)updateConstraints:(void(^)(MASConstraintMaker *make))block;
 - (NSArray *)remakeConstraints:(void(^)(MASConstraintMaker *make))block;
+- (void)removeExistingConstraints;
 
 @end
 
@@ -110,6 +111,9 @@ MAS_ATTR_FORWARD(centerYWithinMargins);
     return [self mas_remakeConstraints:block];
 }
 
+- (void)removeExistingConstraints {
+    [self mas_removeExistingConstraints];
+}
 @end
 
 #endif


### PR DESCRIPTION
I added mas_removeExistingConstraints method to UIView's additions.
Writing codes as below, which can remove all existing constraints from view. But I think this is not good solution.
```obj-c
    [view mas_remakeConstraints:^(MASConstraintMaker *make) { /* Nothing here*/ }];
```

So please consider this PR.